### PR TITLE
Add option for full_refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Each of the above operators accept the following arguments:
   * If set, passed as the `--target` argument to the `dbt` command
 * `dir`
   * The directory to run the `dbt` command in
+* `full_refresh`
+  * If set to `True`, passes `--full-refresh`
 * `vars`
   * If set, passed as the `--vars` argument to the `dbt` command. Should be set as a Python dictionary, as will be passed to the `dbt` command as YAML
 * `models`
@@ -105,7 +107,7 @@ flake8 airflow_dbt/ tests/ setup.py
 
 If you use dbt's package manager you should include all dependencies before deploying your dbt project.
 
-For Docker users, packages specified in `packages.yml` should be included as part your docker image by calling `dbt deps` in your `Dockerfile`.  
+For Docker users, packages specified in `packages.yml` should be included as part your docker image by calling `dbt deps` in your `Dockerfile`.
 
 ## License & Contributing
 

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -19,6 +19,8 @@ class DbtCliHook(BaseHook):
     :type vars: str
     :param vars: If set, passed as the `--vars` argument to the `dbt` command
     :type vars: dict
+    :param full_refresh: If `True`, will fully-refresh incremental models.
+    :type full_refresh: bool
     :param models: If set, passed as the `--models` argument to the `dbt` command
     :type models: str
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
@@ -36,6 +38,7 @@ class DbtCliHook(BaseHook):
                  target=None,
                  dir='.',
                  vars=None,
+                 full_refresh=False,
                  models=None,
                  exclude=None,
                  dbt_bin='dbt',
@@ -45,6 +48,7 @@ class DbtCliHook(BaseHook):
         self.dir = dir
         self.target = target
         self.vars = vars
+        self.full_refresh = full_refresh
         self.models = models
         self.exclude = exclude
         self.dbt_bin = dbt_bin
@@ -84,6 +88,9 @@ class DbtCliHook(BaseHook):
 
         if self.verbose:
             self.log.info(" ".join(dbt_cmd))
+
+        if self.full_refresh:
+            dbt_cmd.extend(['--full-refresh'])
 
         sp = subprocess.Popen(
             dbt_cmd,

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -16,6 +16,8 @@ class DbtBaseOperator(BaseOperator):
     :type vars: str
     :param vars: If set, passed as the `--vars` argument to the `dbt` command
     :type vars: dict
+    :param full_refresh: If `True`, will fully-refresh incremental models.
+    :type full_refresh: bool
     :param models: If set, passed as the `--models` argument to the `dbt` command
     :type models: str
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
@@ -38,6 +40,7 @@ class DbtBaseOperator(BaseOperator):
                  exclude=None,
                  dbt_bin='dbt',
                  verbose=True,
+                 full_refresh=False,
                  *args,
                  **kwargs):
         super(DbtBaseOperator, self).__init__(*args, **kwargs)
@@ -46,6 +49,7 @@ class DbtBaseOperator(BaseOperator):
             target=target,
             dir=dir,
             vars=vars,
+            full_refresh=full_refresh,
             models=models,
             exclude=exclude,
             dbt_bin=dbt_bin,


### PR DESCRIPTION
I'm not sure if this is the best answer, but whenever you make changes to the structure of an incremental model you need to force a full refresh once. Not sure there's any good way to support this other than shipping a version which runs with `full_refresh=True` and then removing that after 🙁 