### PR TITLE
Handle templated vars

### DIFF
--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -30,6 +30,8 @@ class DbtBaseOperator(BaseOperator):
 
     ui_color = '#d6522a'
 
+    template_fields = ['vars']
+
     @apply_defaults
     def __init__(self,
                  profiles_dir=None,
@@ -44,16 +46,30 @@ class DbtBaseOperator(BaseOperator):
                  *args,
                  **kwargs):
         super(DbtBaseOperator, self).__init__(*args, **kwargs)
+
+        self.profiles_dir = profiles_dir
+        self.target = target
+        self.dir = dir
+        self.vars = vars
+        self.models = models
+        self.full_refresh = full_refresh
+        self.exclude = exclude
+        self.dbt_bin = dbt_bin
+        self.verbose = verbose
+
+    def create_hook(self):
         self.hook = DbtCliHook(
-            profiles_dir=profiles_dir,
-            target=target,
-            dir=dir,
-            vars=vars,
-            full_refresh=full_refresh,
-            models=models,
-            exclude=exclude,
-            dbt_bin=dbt_bin,
-            verbose=verbose)
+            profiles_dir=self.profiles_dir,
+            target=self.target,
+            dir=self.dir,
+            vars=self.vars,
+            full_refresh=self.full_refresh,
+            models=self.models,
+            exclude=self.exclude,
+            dbt_bin=self.dbt_bin,
+            verbose=self.verbose)
+        
+        return self.hook
 
 
 class DbtRunOperator(DbtBaseOperator):
@@ -62,7 +78,7 @@ class DbtRunOperator(DbtBaseOperator):
         super(DbtRunOperator, self).__init__(profiles_dir=profiles_dir, target=target, *args, **kwargs)
 
     def execute(self, context):
-        self.hook.run_cli('run')
+        self.create_hook().run_cli('run')
 
 
 class DbtTestOperator(DbtBaseOperator):
@@ -71,4 +87,4 @@ class DbtTestOperator(DbtBaseOperator):
         super(DbtTestOperator, self).__init__(profiles_dir=profiles_dir, target=target, *args, **kwargs)
 
     def execute(self, context):
-        self.hook.run_cli('test')
+        self.create_hook().run_cli('test')

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -69,7 +69,7 @@ class DbtBaseOperator(BaseOperator):
             exclude=self.exclude,
             dbt_bin=self.dbt_bin,
             verbose=self.verbose)
-        
+
         return self.hook
 
 

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -56,6 +56,7 @@ class DbtBaseOperator(BaseOperator):
         self.exclude = exclude
         self.dbt_bin = dbt_bin
         self.verbose = verbose
+        self.create_hook()
 
     def create_hook(self):
         self.hook = DbtCliHook(


### PR DESCRIPTION
Hey! Thanks for sharing this package.

#### Overview

- Handles Jinja template in `vars (--vars)` attribute
- Fixes https://github.com/gocardless/airflow-dbt/issues/7

#### Notes

Templating seems to happen on execution so I think we need to generate the hook there rather than on construction.

If we want to keep creating the hook in the constructor, an alternative could be to implement [render_template_fields()](https://airflow.apache.org/docs/stable/_api/airflow/models/baseoperator/index.html#airflow.models.baseoperator.BaseOperator.render_template_fields) in there. Although this means the function would be called twice (once in the constructor and once when executing).

#### Disclaimer

I'm not a Python pro so this might not be optimized properly. It fixes my issue so I thought I would share.
Feel free to modify/update/do your thing over this :)