### PR TITLE
Handle --select parameter for snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a collection of [Airflow](https://airflow.apache.org/) operators to prov
 
 ```py
 from airflow import DAG
-from airflow_dbt.operators.dbt_operator import DbtRunOperator, DbtTestOperator
+from airflow_dbt.operators.dbt_operator import DbtSnapshotOperator, DbtRunOperator, DbtTestOperator
 from airflow.utils.dates import days_ago
 
 default_args = {
@@ -67,6 +67,8 @@ Each of the above operators accept the following arguments:
   * If set, passed as the `--models` argument to the `dbt` command
 * `exclude`
   * If set, passed as the `--exclude` argument to the `dbt` command
+* `select`
+  * If set, passed as the `--select` argument to the `dbt` command
 * `dbt_bin`
   * The `dbt` CLI. Defaults to `dbt`, so assumes it's on your `PATH`
 * `verbose`

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -41,6 +41,7 @@ class DbtCliHook(BaseHook):
                  full_refresh=False,
                  models=None,
                  exclude=None,
+                 select=None,
                  dbt_bin='dbt',
                  output_encoding='utf-8',
                  verbose=True):
@@ -51,6 +52,7 @@ class DbtCliHook(BaseHook):
         self.full_refresh = full_refresh
         self.models = models
         self.exclude = exclude
+        self.select = select
         self.dbt_bin = dbt_bin
         self.verbose = verbose
         self.output_encoding = output_encoding
@@ -85,6 +87,9 @@ class DbtCliHook(BaseHook):
 
         if self.exclude is not None:
             dbt_cmd.extend(['--exclude', self.exclude])
+
+        if self.select is not None:
+            dbt_cmd.extend(['--select', self.exclude])
 
         if self.full_refresh:
             dbt_cmd.extend(['--full-refresh'])

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -91,7 +91,7 @@ class DbtCliHook(BaseHook):
             dbt_cmd.extend(['--exclude', self.exclude])
 
         if self.select is not None:
-            dbt_cmd.extend(['--select', self.exclude])
+            dbt_cmd.extend(['--select', self.select])
 
         if self.full_refresh:
             dbt_cmd.extend(['--full-refresh'])

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -25,6 +25,8 @@ class DbtCliHook(BaseHook):
     :type models: str
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
     :type exclude: str
+    :param select: If set, passed as the `--select` argument to the `dbt` command
+    :type select: str
     :param dbt_bin: The `dbt` CLI. Defaults to `dbt`, so assumes it's on your `PATH`
     :type dbt_bin: str
     :param output_encoding: Output encoding of bash command. Defaults to utf-8

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -40,6 +40,7 @@ class DbtBaseOperator(BaseOperator):
                  vars=None,
                  models=None,
                  exclude=None,
+                 select=None,
                  dbt_bin='dbt',
                  verbose=True,
                  full_refresh=False,
@@ -54,6 +55,7 @@ class DbtBaseOperator(BaseOperator):
         self.models = models
         self.full_refresh = full_refresh
         self.exclude = exclude
+        self.select = select
         self.dbt_bin = dbt_bin
         self.verbose = verbose
         self.create_hook()
@@ -67,6 +69,7 @@ class DbtBaseOperator(BaseOperator):
             full_refresh=self.full_refresh,
             models=self.models,
             exclude=self.exclude,
+            select=self.select,
             dbt_bin=self.dbt_bin,
             verbose=self.verbose)
 

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -22,6 +22,8 @@ class DbtBaseOperator(BaseOperator):
     :type models: str
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
     :type exclude: str
+    :param select: If set, passed as the `--select` argument to the `dbt` command
+    :type select: str
     :param dbt_bin: The `dbt` CLI. Defaults to `dbt`, so assumes it's on your `PATH`
     :type dbt_bin: str
     :param verbose: The operator will log verbosely to the Airflow logs


### PR DESCRIPTION
The `dbt snapshot` command accepts a `--select` parameter to indicate which snapshots we want to refresh.
See the [snapshot command documentation](https://docs.getdbt.com/reference/commands/snapshot).

This PR proposes a way to handle the `--select` parameter in the `DbtSnapshotOperator`.