### PR TITLE
Add --warn-error option to dbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ It will also need access to the `dbt` CLI, which should either be on your `PATH`
 
 ## Usage
 
-There are four operators currently implemented:
+There are five operators currently implemented:
 
+* `DbtDocsGenerateOperator`
+  * Calls [`dbt docs generate`](https://docs.getdbt.com/reference/commands/cmd-docs)
 * `DbtSeedOperator`
   * Calls [`dbt seed`](https://docs.getdbt.com/docs/seed)
 * `DbtSnapshotOperator`
@@ -85,6 +87,8 @@ Each of the above operators accept the following arguments:
   * The `dbt` CLI. Defaults to `dbt`, so assumes it's on your `PATH`
 * `verbose`
   * The operator will log verbosely to the Airflow logs
+* `warn_error`
+  * If set to `True`, passes `--warn-error` argument to `dbt` command and will treat warnings as errors
 
 Typically you will want to use the `DbtRunOperator`, followed by the `DbtTestOperator`, as shown earlier.
 

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -23,6 +23,8 @@ class DbtCliHook(BaseHook):
     :type full_refresh: bool
     :param models: If set, passed as the `--models` argument to the `dbt` command
     :type models: str
+    :param warn_error: If `True`, treat warnings as errors.
+    :type warn_error: bool
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
     :type exclude: str
     :param select: If set, passed as the `--select` argument to the `dbt` command
@@ -48,7 +50,8 @@ class DbtCliHook(BaseHook):
                  select=None,
                  dbt_bin='dbt',
                  output_encoding='utf-8',
-                 verbose=True):
+                 verbose=True,
+                 warn_error=False):
         self.profiles_dir = profiles_dir
         self.dir = dir
         self.target = target
@@ -61,6 +64,7 @@ class DbtCliHook(BaseHook):
         self.select = select
         self.dbt_bin = dbt_bin
         self.verbose = verbose
+        self.warn_error = warn_error
         self.output_encoding = output_encoding
 
     def _dump_vars(self):
@@ -108,6 +112,9 @@ class DbtCliHook(BaseHook):
 
         if self.verbose:
             self.log.info(" ".join(dbt_cmd))
+
+        if self.warn_error:
+            dbt_cmd.insert(1, '--warn-error')
 
         sp = subprocess.Popen(
             dbt_cmd,

--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -110,11 +110,11 @@ class DbtCliHook(BaseHook):
         if self.full_refresh:
             dbt_cmd.extend(['--full-refresh'])
 
-        if self.verbose:
-            self.log.info(" ".join(dbt_cmd))
-
         if self.warn_error:
             dbt_cmd.insert(1, '--warn-error')
+
+        if self.verbose:
+            self.log.info(" ".join(dbt_cmd))
 
         sp = subprocess.Popen(
             dbt_cmd,

--- a/airflow_dbt/operators/dbt_operator.py
+++ b/airflow_dbt/operators/dbt_operator.py
@@ -20,6 +20,8 @@ class DbtBaseOperator(BaseOperator):
     :type full_refresh: bool
     :param models: If set, passed as the `--models` argument to the `dbt` command
     :type models: str
+    :param warn_error: If `True`, treat warnings as errors.
+    :type warn_error: bool
     :param exclude: If set, passed as the `--exclude` argument to the `dbt` command
     :type exclude: str
     :param select: If set, passed as the `--select` argument to the `dbt` command
@@ -45,6 +47,7 @@ class DbtBaseOperator(BaseOperator):
                  select=None,
                  dbt_bin='dbt',
                  verbose=True,
+                 warn_error=False,
                  full_refresh=False,
                  data=False,
                  schema=False,
@@ -64,6 +67,7 @@ class DbtBaseOperator(BaseOperator):
         self.select = select
         self.dbt_bin = dbt_bin
         self.verbose = verbose
+        self.warn_error = warn_error
         self.create_hook()
 
     def create_hook(self):
@@ -79,7 +83,8 @@ class DbtBaseOperator(BaseOperator):
             exclude=self.exclude,
             select=self.select,
             dbt_bin=self.dbt_bin,
-            verbose=self.verbose)
+            verbose=self.verbose,
+            warn_error=self.warn_error)
 
         return self.hook
 


### PR DESCRIPTION
### Background:
We have recently been tricked by dbt runs that didn't fail but gave a silent warning when models specified could not be found. Although this is inline with [dbt documentation](https://docs.getdbt.com/reference/global-cli-flags#warnings-as-errors), adding the --warn-error option ensures all warnings are thrown as an unhandled exception.

### In this PR:
- Added optional [--warn-error](https://docs.getdbt.com/reference/global-cli-flags#warnings-as-errors) switch in dbt command
- Some updates to README.md to reflect --warn-error added option and availability of DbtDocsGenerateOperator