### PR TITLE
fix: add dbt `env` dict to existing environment

### DIFF
--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -126,10 +126,13 @@ class DbtCliHook(BaseHook):
 
         if self.verbose:
             self.log.info(" ".join(dbt_cmd))
+          
+        dbt_env = os.environ.copy()
+        dbt_env.update(self.env)
 
         sp = subprocess.Popen(
             dbt_cmd,
-            env=self.env,
+            env=dbt_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=self.dir,


### PR DESCRIPTION
This avoids passing in an empty `env` to `subprocess.Popen(`, which results in `dbt command not found` errors when running this code in Composer Airflow