### PR TITLE
fix import in dbt_hook.py

### DIFF
--- a/airflow_dbt/hooks/dbt_hook.py
+++ b/airflow_dbt/hooks/dbt_hook.py
@@ -4,7 +4,7 @@ import signal
 import subprocess
 import json
 from airflow.exceptions import AirflowException
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 
 class DbtCliHook(BaseHook):


### PR DESCRIPTION
Solved issue: import airflow.hooks.base_hook is deprecated #80